### PR TITLE
Fix to image-resize util

### DIFF
--- a/src/modules/business/business-edit.tsx
+++ b/src/modules/business/business-edit.tsx
@@ -61,7 +61,7 @@ export const BusinessEdit = ({
                 name="image"
                 required="true"
                 placeholder="https://scontent.cdninstagram.com/v/"
-                value={business.image || ""}
+                value={business.image}
                 type="file"
                 title="Podes copiar tu imagen de Instagram"
               />

--- a/src/utils/image-resize.ts
+++ b/src/utils/image-resize.ts
@@ -5,15 +5,15 @@ import { supabase as supabaseClient } from "utils/supabase"
 /**This function returns an object with two keys: 
  * @result returned by the Supabase upload function. This object returns among other things, an error, so to check for error, simply use result.error.
  * @image_url a string that points to the image resource stored in the Supabase bucket*/
-export default async function imageResizer(file: Blob, file_name: String) {
+export default async function imageResizer(file: Blob, business_name: String) {
 
   const fileSize = file.size;
   const factor = 100000 / fileSize;
   let image = await file!.arrayBuffer()
   //Before uploading the image I make sure to remove every space and replace it with an underscore and then normalize it too to remove accent marks to reduce the chance of having trouble with the URL.
-  console.log(file_name)
-  file_name.normalize("NFKC").replaceAll(" ", "_").replace(/[^\w]/g, '')
-  console.log(file_name.replaceAll(" ", "_").normalize())
+
+  business_name.normalize("NFD").replace(/[\u0300-\u036f]/g, '').replaceAll(" ", "_").toLowerCase();
+  const file_name = business_name.normalize("NFD").replace(/[\u0300-\u036f]/g, '').replaceAll(" ", "_").toLowerCase();
   console.log("Image size:", fileSize * 0.0009765625 + "KB")
   console.log("Factor: ", factor)
 


### PR DESCRIPTION
Había un problema con el file_name. Al asignarle un nombre a la imagen (file name) yo estaba usando el nombre del negocio. Ejemplo, "La burguesía" contenía una tilde, espacios y una mayúscula. Ahora el usuario puede ingresar cualquier nombre y el image-resize va a automáticamente convertir ese nombre.
-> "La burguesía"
=> "la_burguesia.jpg"